### PR TITLE
Freeze the Android tools version - Fixes #41

### DIFF
--- a/src/android_sdk.py
+++ b/src/android_sdk.py
@@ -177,7 +177,7 @@ class AndroidSDK:
             logger.info('Downloading and installing Android SDK...')
 
             # Download
-            r = requests.get('https://developer.android.com/studio/')
+            r = requests.get('https://web.archive.org/web/20190403122148/https://developer.android.com/studio/')
 
             if r.status_code != 200:
                 logger.error('Failed GET request to developer.android.com')


### PR DESCRIPTION
The script tries to find the latest Android tools version on this page:

    https://developer.android.com/studio/

However, it's structure has changed. There is no particular reason to force the latest tools so we might also use an archived version as a quick fix.

    https://web.archive.org/web/20190403122148/https://developer.android.com/studio/