### PR TITLE
Update after changes in Android SDK

### DIFF
--- a/src/android_sdk.py
+++ b/src/android_sdk.py
@@ -183,7 +183,7 @@ class AndroidSDK:
                 logger.error('Failed GET request to developer.android.com')
                 return False
 
-            sdk_re = re.search(r'https://dl.google.com/android/repository/sdk-tools-' + platform.system().lower() + '-(\d+).zip', r.text)
+            sdk_re = re.search(r'https://dl.google.com/android/repository/commandlinetools-' + platform.system().lower() + '-\d+.*\.zip', r.text)
 
             if not sdk_re:
                 logger.error('Failed regex matching to find latest Android SDK (platform %s)', platform.system())

--- a/src/android_sdk.py
+++ b/src/android_sdk.py
@@ -167,7 +167,7 @@ class AndroidSDK:
 
     def _download(self, extract_dir):
         output_zip = os.path.join(extract_dir, 'tools.zip')
-        tools_dir = os.path.join(extract_dir, 'tools')
+        tools_dir = os.path.join(extract_dir, 'cmdline-tools', 'tools')
 
         if os.path.exists(tools_dir):
             logger.info('SDK tools directory already exists, skipping download & extraction...')
@@ -206,7 +206,7 @@ class AndroidSDK:
 
         # Extraction
         z = zipfile.ZipFile(output_zip)
-        z.extractall(extract_dir)
+        z.extractall(os.path.dirname(tools_dir))
 
         logger.info('Android SDK successfully extracted in android-sdk/')
 
@@ -234,9 +234,9 @@ class AndroidSDK:
         if type == CommandType.PLATFORM_TOOLS:
             path = os.path.join(self._sdk_path, 'platform-tools')
         elif type == CommandType.TOOLS:
-            path = os.path.join(self._sdk_path, 'tools')
+            path = os.path.join(self._sdk_path, 'emulator')
         elif type == CommandType.TOOLS_BIN:
-            path = os.path.join(self._sdk_path, 'tools', 'bin')
+            path = os.path.join(self._sdk_path, 'cmdline-tools', 'tools', 'bin')
 
             if is_windows:
                 binary = '%s.bat' % binary


### PR DESCRIPTION
I don't have any experience with Android development, but I was trying to figure out why WhatsDump was not working.

The first problems I addressed are about the Android SDK, in particular:
- download
the package name has changed, so I updated the regex which scrapes for the URL
- runtime
according to this https://stackoverflow.com/a/61176718/12494143, the SDK file structure has changed. My changes are more a workaround then a proper fix, let me know your preferences about it and in case we can refactor it accordingly.

For what concerns my problem running Whatsdump, now that the SDK works I'm going to open an issue for it.